### PR TITLE
Add mypy to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,12 @@ repos:
   rev: 0.8.1
   hooks:
     - id: nbstripout
+
+
+- repo: local
+  hooks:
+  - id: mypy
+    name: mypy
+    entry: poetry run mypy
+    language: system
+    types: [file, python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = "3.11.9"
+requires-python = "~3.11.9"
 dependencies = [
     "polars (==1.25.*)",
     "jupyter (>=1.1.1,<2.0.0)",
@@ -32,6 +32,11 @@ nbqa = "^1.9.1"
 isort = "^6.0.1"
 flake8 = "^7.2.0"
 pyupgrade = "^3.19.1"
+mypy = "^1.15.0"
+
+[[tool.mypy.overrides]]
+module = ["crawl4ai.*"]
+ignore_missing_imports = true
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/src/data_quality_utils/crawler/crawler.py
+++ b/src/data_quality_utils/crawler/crawler.py
@@ -84,6 +84,7 @@ class Crawler:
                 keywords=keyword_scorer.get("keywords", []),
                 weight=keyword_scorer.get("weight", 1.0),
             )
+        return None
 
     async def deep_crawl(self, url: str) -> list[tuple[str, str]]:
         """


### PR DESCRIPTION
Small PR to add mypy to our precommit hooks. Using local to stop any mismatches between running the tools ourselves and through pre-commit.

Other minor changes:
- mypy complained about not explicitly returning None in crawler so added that.